### PR TITLE
Doingステータスのタスクを最上部に表示

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,11 +249,17 @@ class TaskManager {
         tasksList.classList.remove('hidden');
         emptyState.classList.add('hidden');
 
-        // アクティブなタスク（未完了）を上に、完了タスクを下に
+        // ソート順: Doing → Unstarted → Done
         const sortedTasks = [...this.tasks].sort((a, b) => {
-            if (a.status === 'done' && b.status !== 'done') return 1;
-            if (a.status !== 'done' && b.status === 'done') return -1;
-            return 0;
+            // ステータスの優先順位を定義
+            const statusPriority = {
+                'doing': 0,
+                'unstarted': 1,
+                'done': 2
+            };
+            
+            // 優先順位で比較
+            return statusPriority[a.status] - statusPriority[b.status];
         });
 
         tasksList.innerHTML = sortedTasks.map(task => this.renderTask(task)).join('');


### PR DESCRIPTION
## 概要
Issue #2 を解決: Doingステータスのタスクを常にリストの最上部に表示するように変更しました。

## 変更内容
- タスクリストのソート順を変更
- 新しい優先順位:
  1. **Doing** (進行中) - 最上部
  2. **Unstarted** (未開始) - 中間
  3. **Done** (完了) - 最下部

## 解決される問題
- 現在作業中のタスクが埋もれてしまう問題
- 進行中タスクの視認性が低い問題

## 動作確認
1. 複数のタスクを作成
2. いくつかのタスクをDoingステータスに変更
3. Doingタスクが自動的にリストの上部に移動することを確認
4. タスクの優先順位が正しく表示されることを確認

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)