### PR TITLE
ドラッグ&ドロップでタスクの順序変更機能

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -578,24 +578,14 @@ footer {
     position: relative;
     display: flex;
     align-items: center;
-    gap: 10px;
-}
-
-/* ドラッグハンドル */
-.drag-handle {
+    gap: 15px;
     cursor: grab;
-    color: var(--color-text-light);
-    padding: 5px;
-    opacity: 0.5;
-    transition: opacity 0.2s ease;
-    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
-.drag-handle:hover {
-    opacity: 1;
-}
-
-.drag-handle:active {
+.task-item:active {
     cursor: grabbing;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -214,12 +214,8 @@ header h1 {
     border-radius: var(--border-radius);
     padding: 15px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.05);
-    display: flex;
-    align-items: center;
-    gap: 15px;
     transition: var(--transition);
     cursor: pointer;
-    position: relative;
 }
 
 .task-item:hover {
@@ -580,6 +576,39 @@ footer {
 .task-item {
     animation: slideIn 0.3s ease;
     position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* ドラッグハンドル */
+.drag-handle {
+    cursor: grab;
+    color: var(--color-text-light);
+    padding: 5px;
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+    touch-action: none;
+}
+
+.drag-handle:hover {
+    opacity: 1;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+/* ドラッグ中のスタイル */
+.task-item.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+}
+
+/* ドロップ対象のスタイル */
+.task-item.drag-over {
+    border-top: 3px solid var(--color-base);
+    padding-top: 12px;
 }
 
 /* ステータス変更オーバーレイ */


### PR DESCRIPTION
## 📝 概要
Issue #5 を解決: タスクをドラッグ&ドロップで並び替えできる機能を追加しました。

## ✨ 新機能
- **ドラッグハンドル**: 各タスクの左側に「⋮」アイコンを追加
- **ドラッグ&ドロップ**: ハンドルをつかんでタスクを上下に移動
- **モバイル対応**: iPhone Safariでもタッチ操作で並び替え可能
- **順序の保存**: カスタム順序はLocal Storageに保存され、リロード後も維持

## 🎯 技術詳細

### デスクトップ
- HTML5 Drag and Drop APIを使用
- `dragstart`, `dragend`, `dragover`, `drop`イベントを処理

### モバイル（iPhone Safari）
- Touch Events APIを使用
- `touchstart`, `touchmove`, `touchend`イベントを処理
- ドラッグハンドルをタッチした場合のみドラッグ開始

### 表示優先順位
1. **カスタム順序**（ドラッグで変更した順序）
2. **ステータス順**（Doing → Unstarted → Done）

## 🎨 UIの改善
- ドラッグ中: タスクが半透明になる
- ドロップ位置: 青い線で表示
- ドラッグハンドル: ホバー時に濃くなる

## 🧪 テスト方法

### デスクトップ
1. タスクの左側の「⋮」アイコンをドラッグ
2. 別のタスクの位置にドロップ
3. 順序が変更されることを確認

### モバイル
1. iPhoneのSafariでアクセス
2. 「⋮」アイコンを長押ししてドラッグ
3. 別の位置で指を離す
4. 順序が変更されることを確認

### 永続性の確認
1. タスクの順序を変更
2. ページをリロード
3. 変更した順序が維持されることを確認

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)