### PR TITLE
チェックボックスとポイント表示の位置を入れ替え

### DIFF
--- a/app.js
+++ b/app.js
@@ -349,13 +349,13 @@ class TaskManager {
             <div class="task-item ${task.status} pt-${task.points}" 
                  data-task-id="${task.id}"
                  draggable="true">
+                <div class="task-content">
+                    <span class="task-point pt-${task.points}">${task.points}pt</span>
+                    <span class="task-title">${this.escapeHtml(task.title)}</span>
+                </div>
                 <button class="task-status-btn" data-action="status" data-task-id="${task.id}">
                     ${statusIcon[task.status]}
                 </button>
-                <div class="task-content">
-                    <span class="task-title">${this.escapeHtml(task.title)}</span>
-                    <span class="task-point pt-${task.points}">${task.points}pt</span>
-                </div>
             </div>
         `;
     }

--- a/styles.css
+++ b/styles.css
@@ -388,6 +388,7 @@ header h1 {
 .task-title {
     flex: 1;
     font-size: 1rem;
+    margin-right: 10px;
 }
 
 .task-point {
@@ -396,6 +397,7 @@ header h1 {
     font-size: 0.85rem;
     font-weight: 500;
     color: var(--color-white);
+    margin-right: 10px;
 }
 
 .task-item.unstarted .task-point,


### PR DESCRIPTION
## Summary
- チェックボックスを右側に移動し、ポイント表示を左側に配置
- 右利きユーザーがスマホで操作しやすくなるように改善

## Changes
- `app.js`: タスクアイテムのHTML構造を変更
- `styles.css`: レイアウト調整のためのマージン追加

Fixes #11

## Test plan
- [x] タスクの表示が正しく入れ替わっていることを確認
- [x] チェックボックスのクリック動作が正常に機能することを確認
- [x] ドラッグ&ドロップ機能が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)