### PR TITLE
fix: PWAキャッシュ問題の解決

### DIFF
--- a/cache-cleaner.js
+++ b/cache-cleaner.js
@@ -1,0 +1,52 @@
+// PWAキャッシュクリーナー
+// 古いService Workerの登録解除とキャッシュのクリアを行います
+
+(function() {
+    // Service Workerの登録解除
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function(registrations) {
+            for(let registration of registrations) {
+                registration.unregister().then(function(success) {
+                    if (success) {
+                        console.log('Service Worker unregistered successfully');
+                    }
+                });
+            }
+        });
+    }
+
+    // すべてのキャッシュをクリア
+    if ('caches' in window) {
+        caches.keys().then(function(cacheNames) {
+            return Promise.all(
+                cacheNames.map(function(cacheName) {
+                    return caches.delete(cacheName).then(function() {
+                        console.log('Cache deleted:', cacheName);
+                    });
+                })
+            );
+        }).then(function() {
+            console.log('All caches cleared');
+        });
+    }
+
+    // バージョン管理用のタイムスタンプをローカルストレージに保存
+    // これにより、クライアント側で更新を検知できます
+    const CACHE_VERSION_KEY = 'ktra_cache_version';
+    const currentVersion = Date.now().toString();
+    const storedVersion = localStorage.getItem(CACHE_VERSION_KEY);
+
+    if (storedVersion !== currentVersion) {
+        // バージョンが異なる場合、強制リロード
+        localStorage.setItem(CACHE_VERSION_KEY, currentVersion);
+
+        // 初回訪問でない場合のみリロード
+        if (storedVersion) {
+            console.log('Cache version updated, reloading page...');
+            // 少し遅延を入れてキャッシュクリアを確実に完了させる
+            setTimeout(() => {
+                window.location.reload(true);
+            }, 500);
+        }
+    }
+})();

--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>K-tra - The Lightweight Task Tracker</title>
+
+    <!-- キャッシュ制御 -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <!-- SEO & Social -->
     <meta name="description" content="楽しいストーリーポイント管理でタスクをゲーム化">
     <meta property="og:title" content="Ktra - タスク管理アプリ">
@@ -177,6 +182,8 @@
         </div>
     </div>
 
+    <!-- Service Worker / PWAキャッシュクリーナー -->
+    <script src="cache-cleaner.js"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
PWA対応を撤回した後もSafari等でキャッシュが強く残る問題を解決します。

## 変更内容
- Service Worker登録解除とキャッシュクリアを行う `cache-cleaner.js` を追加
- HTTPキャッシュ制御のメタタグを追加してブラウザキャッシュを無効化
- バージョン管理による自動更新検知機能を実装

## 動作説明
1. ページ読み込み時に既存のService Worker登録をすべて解除
2. 保存されているすべてのキャッシュを削除
3. バージョン番号をローカルストレージで管理し、更新時に自動リロード
4. HTTPヘッダーレベルでもキャッシュを無効化

## テスト方法
1. iPhoneのSafariでサイトにアクセス
2. 設定 > Safari > 詳細 > Webサイトデータから該当サイトのデータを削除
3. サイトに再アクセスして最新版が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)