### PR TITLE
fix: Safari向けのより強力なキャッシュバスティング実装

### DIFF
--- a/cache-cleaner.js
+++ b/cache-cleaner.js
@@ -33,20 +33,31 @@
     // バージョン管理用のタイムスタンプをローカルストレージに保存
     // これにより、クライアント側で更新を検知できます
     const CACHE_VERSION_KEY = 'ktra_cache_version';
-    const currentVersion = Date.now().toString();
+    const FORCE_VERSION = '2025.1.14.1'; // 手動でバージョンを更新
     const storedVersion = localStorage.getItem(CACHE_VERSION_KEY);
 
-    if (storedVersion !== currentVersion) {
+    if (storedVersion !== FORCE_VERSION) {
         // バージョンが異なる場合、強制リロード
-        localStorage.setItem(CACHE_VERSION_KEY, currentVersion);
+        localStorage.setItem(CACHE_VERSION_KEY, FORCE_VERSION);
 
         // 初回訪問でない場合のみリロード
         if (storedVersion) {
-            console.log('Cache version updated, reloading page...');
+            console.log('Cache version updated from', storedVersion, 'to', FORCE_VERSION, ', reloading page...');
             // 少し遅延を入れてキャッシュクリアを確実に完了させる
             setTimeout(() => {
-                window.location.reload(true);
+                // より強力なリロード: URLにタイムスタンプを追加
+                const url = new URL(window.location.href);
+                url.searchParams.set('v', Date.now());
+                window.location.href = url.toString();
             }, 500);
         }
+    }
+
+    // Safari特有の追加対策: sessionStorageもクリア
+    try {
+        sessionStorage.clear();
+        console.log('SessionStorage cleared');
+    } catch(e) {
+        console.log('Could not clear sessionStorage:', e);
     }
 })();

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta property="og:description" content="楽しいストーリーポイント管理でタスクをゲーム化">
     <meta property="og:type" content="website">
     
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=2025.1.14.1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
@@ -183,7 +183,7 @@
     </div>
 
     <!-- Service Worker / PWAキャッシュクリーナー -->
-    <script src="cache-cleaner.js"></script>
-    <script src="app.js"></script>
+    <script src="cache-cleaner.js?v=2025.1.14.1"></script>
+    <script src="app.js?v=2025.1.14.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## 問題
iPhoneのSafariで前回のPWAキャッシュが残り続けて更新が反映されない

## 解決策
より強力なキャッシュバスティング機能を実装：

1. **固定バージョン番号制御** - `2025.1.14.1`という固定バージョンで確実に更新を検知
2. **URLパラメータによる強制リロード** - リロード時にタイムスタンプをURLに追加
3. **sessionStorageのクリア** - Safari特有のキャッシュ対策
4. **静的ファイルのバージョニング** - CSS/JSファイルにバージョンパラメータを追加

## 確認方法
1. マージ後、GitHub Pagesのデプロイを待つ
2. iPhoneのSafariでサイトにアクセス
3. 自動的にリロードされ、最新版が表示される

もしそれでも更新されない場合は：
- Safari設定 > 詳細 > Webサイトデータ > 該当サイトを削除
- またはプライベートブラウジングモードで確認

🤖 Generated with [Claude Code](https://claude.ai/code)