### PR TITLE
feat: 全体的なデザインの刷新

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <header>
             <div class="header-content">
                 <img src="images/ktra.svg" alt="Ktra Logo" class="logo">
-                <h1>Ktra!</h1>
+                <h1>K-tra!</h1>
                 <p class="tagline">- The Lightweight Task Tracker</p>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -26,8 +26,11 @@
 <body>
     <div class="container">
         <header>
-            <h1>K-tra</h1>
-            <p class="tagline">The Lightweight Task Tracker</p>
+            <div class="header-content">
+                <img src="images/ktra.svg" alt="Ktra Logo" class="logo">
+                <h1>Ktra!</h1>
+                <p class="tagline">- The Lightweight Task Tracker</p>
+            </div>
         </header>
 
         <main>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <div class="header-content">
                 <img src="images/ktra.svg" alt="Ktra Logo" class="logo">
                 <h1>K-tra!</h1>
-                <p class="tagline">- The Lightweight Task Tracker</p>
+                <p class="tagline">The Lightweight Task Tracker</p>
             </div>
         </header>
 

--- a/styles.css
+++ b/styles.css
@@ -184,14 +184,14 @@ header h1 {
 }
 
 .btn-primary {
-    background-color: #1f3466;
+    background-color: #3a4a5c;
     color: var(--color-white);
     width: 100%;
     justify-content: center;
 }
 
 .btn-primary:hover {
-    background-color: #1f3466;
+    background-color: #3a4a5c;
     opacity: 0.9;
     transform: translateY(-2px);
 }
@@ -209,7 +209,7 @@ header h1 {
 .btn-link {
     background: none;
     border: none;
-    color: #1f3466;
+    color: #3a4a5c;
     cursor: pointer;
     padding: 10px;
     font-size: 0.95rem;
@@ -220,7 +220,7 @@ header h1 {
 }
 
 .btn-link:hover {
-    color: #1f3466;
+    color: #3a4a5c;
     opacity: 0.8;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -67,7 +67,7 @@ header h1 {
 
 .tagline {
     color: var(--color-white);
-    font-size: 0.9rem;
+    font-size: 1rem;
     margin: 0;
     opacity: 0.9;
 }
@@ -710,7 +710,7 @@ footer {
     }
 
     .tagline {
-        font-size: 0.8rem;
+        font-size: 0.9rem;
     }
 
     .point-selector {

--- a/styles.css
+++ b/styles.css
@@ -208,7 +208,7 @@ header h1 {
 .btn-link {
     background: none;
     border: none;
-    color: var(--color-base);
+    color: #1f3466;
     cursor: pointer;
     padding: 10px;
     font-size: 0.95rem;
@@ -219,7 +219,8 @@ header h1 {
 }
 
 .btn-link:hover {
-    color: #3a7bc8;
+    color: #1f3466;
+    opacity: 0.8;
 }
 
 /* 週間サマリー */

--- a/styles.css
+++ b/styles.css
@@ -352,28 +352,51 @@ header h1 {
 
 .task-item.doing .task-status-btn {
     background: var(--color-white);
-    border-color: var(--color-white);
     position: relative;
+}
+
+.task-item.doing.pt-0 .task-status-btn {
+    border-color: var(--color-pt0);
 }
 
 .task-item.doing.pt-0 .task-status-btn i {
     color: var(--color-pt0);
 }
 
+.task-item.doing.pt-1 .task-status-btn {
+    border-color: var(--color-pt1);
+}
+
 .task-item.doing.pt-1 .task-status-btn i {
     color: var(--color-pt1);
+}
+
+.task-item.doing.pt-2 .task-status-btn {
+    border-color: var(--color-pt2);
 }
 
 .task-item.doing.pt-2 .task-status-btn i {
     color: var(--color-pt2);
 }
 
+.task-item.doing.pt-3 .task-status-btn {
+    border-color: var(--color-pt3);
+}
+
 .task-item.doing.pt-3 .task-status-btn i {
     color: var(--color-pt3);
 }
 
+.task-item.doing.pt-5 .task-status-btn {
+    border-color: var(--color-pt5);
+}
+
 .task-item.doing.pt-5 .task-status-btn i {
     color: var(--color-pt5);
+}
+
+.task-item.doing.pt-8 .task-status-btn {
+    border-color: var(--color-pt8);
 }
 
 .task-item.doing.pt-8 .task-status-btn i {

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,18 @@
 :root {
-    --color-base: #4a90e2;
+    --color-base: #dbbea1;
     --color-background: #f5f7fa;
     --color-white: #ffffff;
     --color-text: #333333;
     --color-text-light: #666666;
     --color-border: #e1e8ed;
-    
+
     /* ポイント別カラー */
     --color-pt0: #95a5a6;
-    --color-pt1: #3498db;
-    --color-pt2: #2ecc71;
-    --color-pt3: #f39c12;
-    --color-pt5: #e74c3c;
-    --color-pt8: #9b59b6;
+    --color-pt1: #578fcc;
+    --color-pt2: #30ad93;
+    --color-pt3: #ddb51c;
+    --color-pt5: #d97e30;
+    --color-pt8: #c8560b;
     
     --max-width: 480px;
     --border-radius: 8px;
@@ -27,7 +27,7 @@
 
 body {
     font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--color-background);
+    background-color: var(--color-base);
     color: var(--color-text);
     line-height: 1.6;
     min-height: 100vh;
@@ -41,22 +41,36 @@ body {
 
 /* ヘッダー */
 header {
-    text-align: center;
     margin-bottom: 30px;
     padding: 20px 0;
 }
 
+.header-content {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+}
+
+.logo {
+    width: 40px;
+    height: 40px;
+    filter: brightness(0) invert(1);
+}
+
 header h1 {
-    color: var(--color-base);
-    font-size: 2.5rem;
+    color: var(--color-white);
+    font-size: 2rem;
     font-weight: 400;
     letter-spacing: -1px;
+    margin: 0;
 }
 
 .tagline {
-    color: var(--color-text-light);
+    color: var(--color-white);
     font-size: 0.9rem;
-    margin-top: 5px;
+    margin: 0;
+    opacity: 0.9;
 }
 
 /* フォーム */
@@ -288,11 +302,11 @@ header h1 {
 }
 
 .task-item.unstarted .task-status-btn {
-    border-color: var(--color-base);
+    border-color: var(--color-text-light);
 }
 
 .task-item.unstarted .task-status-btn i {
-    color: var(--color-base);
+    color: var(--color-text-light);
 }
 
 /* Doingステータス - ポイント別背景色 */
@@ -683,8 +697,21 @@ footer {
         padding: 15px;
     }
 
+    .header-content {
+        flex-wrap: wrap;
+    }
+
+    .logo {
+        width: 32px;
+        height: 32px;
+    }
+
     header h1 {
-        font-size: 2rem;
+        font-size: 1.5rem;
+    }
+
+    .tagline {
+        font-size: 0.8rem;
     }
 
     .point-selector {

--- a/styles.css
+++ b/styles.css
@@ -303,12 +303,52 @@ header h1 {
     transform: scale(1.1);
 }
 
-.task-item.unstarted .task-status-btn {
-    border-color: var(--color-text-light);
+.task-item.unstarted.pt-0 .task-status-btn {
+    border-color: var(--color-pt0);
 }
 
-.task-item.unstarted .task-status-btn i {
-    color: var(--color-text-light);
+.task-item.unstarted.pt-0 .task-status-btn i {
+    color: var(--color-pt0);
+}
+
+.task-item.unstarted.pt-1 .task-status-btn {
+    border-color: var(--color-pt1);
+}
+
+.task-item.unstarted.pt-1 .task-status-btn i {
+    color: var(--color-pt1);
+}
+
+.task-item.unstarted.pt-2 .task-status-btn {
+    border-color: var(--color-pt2);
+}
+
+.task-item.unstarted.pt-2 .task-status-btn i {
+    color: var(--color-pt2);
+}
+
+.task-item.unstarted.pt-3 .task-status-btn {
+    border-color: var(--color-pt3);
+}
+
+.task-item.unstarted.pt-3 .task-status-btn i {
+    color: var(--color-pt3);
+}
+
+.task-item.unstarted.pt-5 .task-status-btn {
+    border-color: var(--color-pt5);
+}
+
+.task-item.unstarted.pt-5 .task-status-btn i {
+    color: var(--color-pt5);
+}
+
+.task-item.unstarted.pt-8 .task-status-btn {
+    border-color: var(--color-pt8);
+}
+
+.task-item.unstarted.pt-8 .task-status-btn i {
+    color: var(--color-pt8);
 }
 
 /* Doingステータス - ポイント別背景色 */

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,7 @@ header h1 {
     font-size: 1rem;
     margin: 0;
     opacity: 0.9;
+    letter-spacing: 1px;
 }
 
 /* フォーム */

--- a/styles.css
+++ b/styles.css
@@ -53,8 +53,8 @@ header {
 }
 
 .logo {
-    width: 48px;
-    height: 48px;
+    width: 56px;
+    height: 56px;
 }
 
 header h1 {
@@ -703,8 +703,8 @@ footer {
     }
 
     .logo {
-        width: 40px;
-        height: 40px;
+        width: 48px;
+        height: 48px;
     }
 
     header h1 {

--- a/styles.css
+++ b/styles.css
@@ -184,14 +184,15 @@ header h1 {
 }
 
 .btn-primary {
-    background-color: var(--color-base);
+    background-color: #1f3466;
     color: var(--color-white);
     width: 100%;
     justify-content: center;
 }
 
 .btn-primary:hover {
-    background-color: #3a7bc8;
+    background-color: #1f3466;
+    opacity: 0.9;
     transform: translateY(-2px);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -477,7 +477,7 @@ header h1 {
 
 .task-point .point-number {
     font-family: "Staatliches", sans-serif;
-    font-size: 1.5rem;
+    font-size: 2rem;
     font-weight: 400;
     letter-spacing: 0.05em;
     display: block;

--- a/styles.css
+++ b/styles.css
@@ -55,13 +55,12 @@ header {
 .logo {
     width: 40px;
     height: 40px;
-    filter: brightness(0) invert(1);
 }
 
 header h1 {
     color: var(--color-white);
     font-size: 2rem;
-    font-weight: 400;
+    font-weight: 900;
     letter-spacing: -1px;
     margin: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -53,8 +53,8 @@ header {
 }
 
 .logo {
-    width: 40px;
-    height: 40px;
+    width: 48px;
+    height: 48px;
 }
 
 header h1 {
@@ -701,8 +701,8 @@ footer {
     }
 
     .logo {
-        width: 32px;
-        height: 32px;
+        width: 40px;
+        height: 40px;
     }
 
     header h1 {


### PR DESCRIPTION
## Summary
- 全体的な配色とレイアウトを刷新
- ヘッダーにロゴを追加し、横並びレイアウトに変更
- より洗練されたデザインに改善

## Changes
- 背景色を#dbbea1に変更
- ポイント別カラーを新配色に更新
- ヘッダーにロゴ画像（images/ktra.svg）を追加
- タイトルを「Ktra!」に変更
- ヘッダーテキストを白色に統一
- タスクポイント数字を2remに拡大

## Issue
Fixes #28

## Test plan
- [ ] ロゴが正しく表示されることを確認
- [ ] ヘッダーが横並びレイアウトで表示されることを確認
- [ ] 新しい配色が全体に適用されていることを確認
- [ ] レスポンシブデザインが機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)