### PR TITLE
feat: タスク作成をポイントボタンクリックで即座に実行

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,16 @@ class TaskManager {
             this.addTask();
         });
 
+        // ポイントボタンクリックで即座にsubmit
+        document.querySelectorAll('#new-task-form input[name="points"]').forEach(radio => {
+            radio.addEventListener('change', () => {
+                const titleInput = document.getElementById('task-title');
+                if (titleInput.value.trim()) {
+                    this.addTask();
+                }
+            });
+        });
+
         // 編集フォーム
         document.getElementById('edit-task-form').addEventListener('submit', (e) => {
             e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -89,11 +89,6 @@
                             </span>
                         </label>
                     </div>
-
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-plus"></i>
-                        Add Task
-                    </button>
                 </form>
             </section>
 

--- a/styles.css
+++ b/styles.css
@@ -75,10 +75,8 @@ header h1 {
 
 /* フォーム */
 .task-form {
-    background: var(--color-white);
-    border-radius: var(--border-radius);
-    padding: 20px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+    background: transparent;
+    padding: 10px 0;
     margin-bottom: 20px;
 }
 
@@ -93,6 +91,7 @@ header h1 {
     border-radius: var(--border-radius);
     font-size: 1rem;
     transition: var(--transition);
+    background: var(--color-white);
 }
 
 .task-input:focus {
@@ -123,11 +122,11 @@ header h1 {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    width: 52px;
-    height: 52px;
+    width: 56px;
+    height: 56px;
     border-radius: 50%;
-    background: var(--color-border);
-    color: var(--color-text);
+    background: var(--color-white);
+    border: 2px solid var(--color-border);
     cursor: pointer;
     transition: var(--transition);
     line-height: 1;
@@ -141,6 +140,37 @@ header h1 {
     display: block;
 }
 
+/* ポイントバッジの色 */
+.point-badge.pt-0 .point-number,
+.point-badge.pt-0 .point-unit {
+    color: var(--color-pt0);
+}
+
+.point-badge.pt-1 .point-number,
+.point-badge.pt-1 .point-unit {
+    color: var(--color-pt1);
+}
+
+.point-badge.pt-2 .point-number,
+.point-badge.pt-2 .point-unit {
+    color: var(--color-pt2);
+}
+
+.point-badge.pt-3 .point-number,
+.point-badge.pt-3 .point-unit {
+    color: var(--color-pt3);
+}
+
+.point-badge.pt-5 .point-number,
+.point-badge.pt-5 .point-unit {
+    color: var(--color-pt5);
+}
+
+.point-badge.pt-8 .point-number,
+.point-badge.pt-8 .point-unit {
+    color: var(--color-pt8);
+}
+
 .point-badge .point-unit {
     font-family: "Lato", sans-serif;
     font-size: 0.65rem;
@@ -152,8 +182,7 @@ header h1 {
 
 .point-label input[type="radio"]:checked + .point-badge {
     color: var(--color-white);
-    width: 56px;
-    height: 56px;
+    border: none;
 }
 
 .pt-0 { background-color: var(--color-pt0); }
@@ -784,11 +813,6 @@ footer {
     }
 
     .point-badge {
-        width: 44px;
-        height: 44px;
-    }
-
-    .point-label input[type="radio"]:checked + .point-badge {
         width: 48px;
         height: 48px;
     }


### PR DESCRIPTION
## Summary
- ポイントボタンクリックで即座にタスクを登録する新しいUXを実装
- Add Taskボタンを削除してよりシンプルなインターフェースに
- フォームデザインを刷新

## Changes
### 機能変更
- ポイントボタンクリック時に即座にタスクを登録（タイトル入力済みの場合）
- Add Taskボタンを削除

### デザイン変更
- フォームの白枠を削除して背景を透明に
- ポイントボタンのデザインを変更
  - 非選択時：白背景＋ポイント色の文字＋グレーボーダー
  - 選択時：ポイント色背景＋白文字
- すべてのポイントボタンを同じサイズ（56x56px）に統一

## Issue
Fixes #15

## Test plan
- [ ] タイトル入力後、ポイントボタンをクリックすると即座にタスクが登録されることを確認
- [ ] タイトル未入力時はポイントボタンをクリックしても登録されないことを確認
- [ ] ポイントボタンのデザインが正しく表示されることを確認
- [ ] モバイル表示でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)