### PR TITLE
完了から2週間経過したタスクを自動削除する機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,6 +93,7 @@ class TaskManager {
         }
 
         // データを保存
+        this.cleanupOldDoneTasks(); // 古い完了タスクを自動削除
         this.saveTasks();
         
         // アニメーション表示（render前に実行）
@@ -215,6 +216,7 @@ class TaskManager {
         }
         
         this.updateStatusButtons(status);
+        this.cleanupOldDoneTasks(); // 古い完了タスクを自動削除
         this.saveTasks();
         this.render();
     }

--- a/app.js
+++ b/app.js
@@ -61,6 +61,7 @@ class TaskManager {
         };
 
         this.tasks.unshift(task); // 新しいタスクを先頭に追加
+        this.cleanupOldDoneTasks(); // 古い完了タスクを自動削除
         this.saveTasks();
         this.render();
 
@@ -161,6 +162,7 @@ class TaskManager {
         task.title = document.getElementById('edit-task-title').value.trim();
         task.points = parseInt(document.querySelector('input[name="edit-points"]:checked').value);
 
+        this.cleanupOldDoneTasks(); // 古い完了タスクを自動削除
         this.saveTasks();
         this.render();
         this.closeEditModal();
@@ -169,13 +171,27 @@ class TaskManager {
     // タスクの削除
     deleteTask() {
         if (!this.currentEditingTaskId) return;
-        
+
         if (confirm('本当にこのタスクを削除しますか？')) {
             this.tasks = this.tasks.filter(t => t.id !== this.currentEditingTaskId);
             this.saveTasks();
             this.render();
             this.closeEditModal();
         }
+    }
+
+    // 古い完了タスクの自動削除（2週間以上経過したもの）
+    cleanupOldDoneTasks() {
+        const twoWeeksAgo = new Date();
+        twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+        this.tasks = this.tasks.filter(task => {
+            if (task.status !== 'done' || !task.completedAt) {
+                return true;
+            }
+            const completedDate = new Date(task.completedAt);
+            return completedDate > twoWeeksAgo;
+        });
     }
 
     // 編集モーダルを閉じる


### PR DESCRIPTION
## Summary
- doneステータスになってから2週間以上経過したタスクを自動的に削除する機能を追加
- 新規タスクsubmit時と既存タスクedit時の両方で自動削除を実行
- ユーザーへの確認なく、バックグラウンドで静かに削除

## Test plan
- [x] 新規タスクを追加し、古い完了タスク（completedAtが2週間以上前）が削除されることを確認
- [x] 既存タスクを編集し、古い完了タスクが削除されることを確認
- [x] 2週間未満の完了タスクが削除されないことを確認
- [x] 未完了タスク（unstarted/doing）が削除されないことを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)